### PR TITLE
Add batch and lazy loading of collections

### DIFF
--- a/cmd/internal/client/batching_client.go
+++ b/cmd/internal/client/batching_client.go
@@ -5,10 +5,14 @@ import (
 	"github.com/OctopusSolutionsEngineering/OctopusTerraformExport/cmd/internal/model/octopus"
 )
 
+// BatchingOctopusApiClient is a wrapper over the regular client that exposes the ability
+// to return a group of resources while making smaller batched requests to the Octopus API.
+// This has the benefit of allowing large collections to be processed in a lazy fashion.
 type BatchingOctopusApiClient[T any] struct {
 	Client OctopusClient
 }
 
+// ResultError captures either a successful result or an error.
 type ResultError[T any] struct {
 	Res T
 	Err error
@@ -29,7 +33,7 @@ func (c *BatchingOctopusApiClient[T]) GetAllResourcesBatch(done <-chan struct{},
 			close(chnl)
 		}()
 
-		for ok := true; ok; ok = (items != 0) {
+		for ok := true; ok; ok = items == pageSize {
 			collection := new(octopus.GeneralCollection[T])
 			err := c.Client.GetAllResources(resourceType, collection, []string{"take", fmt.Sprint(pageSize)}, []string{"skip", fmt.Sprint(skip)})
 

--- a/cmd/internal/client/batching_client.go
+++ b/cmd/internal/client/batching_client.go
@@ -5,7 +5,7 @@ import (
 	"github.com/OctopusSolutionsEngineering/OctopusTerraformExport/cmd/internal/model/octopus"
 )
 
-type GenericOctopusApiClient[T any] struct {
+type BatchingOctopusApiClient[T any] struct {
 	Client OctopusClient
 }
 
@@ -16,7 +16,7 @@ type ResultError[T any] struct {
 
 // GetAllResourcesBatch retrieves all the resources of a given type but in small batches.
 // This allows the resources to be exported in smaller chunks, which is useful for large spaces.
-func (c *GenericOctopusApiClient[T]) GetAllResourcesBatch(done <-chan struct{}, resourceType string) <-chan ResultError[T] {
+func (c *BatchingOctopusApiClient[T]) GetAllResourcesBatch(done <-chan struct{}, resourceType string) <-chan ResultError[T] {
 
 	pageSize := 30
 	chnl := make(chan ResultError[T])

--- a/cmd/internal/client/generic_client.go
+++ b/cmd/internal/client/generic_client.go
@@ -1,0 +1,47 @@
+package client
+
+import (
+	"fmt"
+	"github.com/OctopusSolutionsEngineering/OctopusTerraformExport/cmd/internal/model/octopus"
+)
+
+type GenericOctopusApiClient[T any] struct {
+	Client OctopusClient
+}
+
+type ResultError[T any] struct {
+	Res T
+	Err error
+}
+
+// GetAllResourcesBatch retrieves all the resources of a given type but in small batches.
+// This allows the resources to be exported in smaller chunks, which is useful for large spaces.
+func (c *GenericOctopusApiClient[T]) GetAllResourcesBatch(resourceType string) <-chan ResultError[T] {
+
+	pageSize := 30
+	chnl := make(chan ResultError[T])
+
+	go func() {
+		skip := 0
+		items := 0
+
+		for ok := true; ok; ok = (items != 0) {
+			collection := new(octopus.GeneralCollection[T])
+			err := c.Client.GetAllResources(resourceType, collection, []string{"take", fmt.Sprint(pageSize)}, []string{"skip", fmt.Sprint(skip)})
+
+			if err != nil {
+				chnl <- ResultError[T]{Res: *new(T), Err: err}
+				break
+			}
+
+			for _, item := range collection.Items {
+				chnl <- ResultError[T]{Res: item, Err: nil}
+			}
+
+			items = len(collection.Items)
+			skip += pageSize
+		}
+	}()
+
+	return chnl
+}

--- a/cmd/internal/client/generic_client.go
+++ b/cmd/internal/client/generic_client.go
@@ -44,9 +44,7 @@ func (c *GenericOctopusApiClient[T]) GetAllResourcesBatch(done <-chan struct{}, 
 				case <-done:
 					// Any signal on the done channel means we should stop processing
 					return
-				default:
-					// No messages on the done channel means we send the next item
-					chnl <- ResultError[T]{Res: item, Err: nil}
+				case chnl <- ResultError[T]{Res: item, Err: nil}: // Send the item on the channel
 				}
 			}
 

--- a/cmd/internal/client/generic_client.go
+++ b/cmd/internal/client/generic_client.go
@@ -41,6 +41,8 @@ func (c *GenericOctopusApiClient[T]) GetAllResourcesBatch(resourceType string) <
 			items = len(collection.Items)
 			skip += pageSize
 		}
+
+		close(chnl)
 	}()
 
 	return chnl

--- a/cmd/internal/client/octopus_client.go
+++ b/cmd/internal/client/octopus_client.go
@@ -231,13 +231,7 @@ func (o *OctopusApiClient) getCollectionRequest(resourceType string, queryParams
 	}
 
 	params := url.Values{}
-	foundTake := false
 	for _, q := range queryParams {
-
-		if q[0] == "take" {
-			foundTake = true
-		}
-
 		if len(q) == 1 {
 			params.Add(q[0], "")
 		}
@@ -247,7 +241,8 @@ func (o *OctopusApiClient) getCollectionRequest(resourceType string, queryParams
 		}
 	}
 
-	if !foundTake {
+	// Add default take query param if it was not specified
+	if _, ok := params["take"]; !ok {
 		params.Add("take", "10000")
 	}
 

--- a/cmd/internal/client/octopus_client.go
+++ b/cmd/internal/client/octopus_client.go
@@ -224,8 +224,13 @@ func (o *OctopusApiClient) getCollectionRequest(resourceType string, queryParams
 		return nil, err
 	}
 
-	requestURL := spaceUrl + "/" + resourceType
+	requestURL, err := url.Parse(spaceUrl + "/" + resourceType)
 
+	if err != nil {
+		panic(err)
+	}
+
+	params := url.Values{}
 	foundTake := false
 	for _, q := range queryParams {
 
@@ -234,25 +239,21 @@ func (o *OctopusApiClient) getCollectionRequest(resourceType string, queryParams
 		}
 
 		if len(q) == 1 {
-			requestURL += "&" + url.QueryEscape(q[0])
+			params.Add(q[0], "")
 		}
 
 		if len(q) == 2 {
-			requestURL += "&" + url.QueryEscape(q[0]) + "=" + url.QueryEscape(q[1])
+			params.Add(q[0], q[1])
 		}
 	}
 
 	if !foundTake {
-		if len(queryParams) == 0 {
-			requestURL += "&"
-		} else {
-			requestURL += "?"
-		}
-
-		requestURL += "take=10000"
+		params.Add("take", "10000")
 	}
 
-	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	requestURL.RawQuery = params.Encode()
+
+	req, err := http.NewRequest(http.MethodGet, requestURL.String(), nil)
 
 	if err != nil {
 		return nil, err

--- a/cmd/internal/client/octopus_client.go
+++ b/cmd/internal/client/octopus_client.go
@@ -224,9 +224,14 @@ func (o *OctopusApiClient) getCollectionRequest(resourceType string, queryParams
 		return nil, err
 	}
 
-	requestURL := spaceUrl + "/" + resourceType + "?take=10000"
+	requestURL := spaceUrl + "/" + resourceType
 
+	foundTake := false
 	for _, q := range queryParams {
+
+		if q[0] == "take" {
+			foundTake = true
+		}
 
 		if len(q) == 1 {
 			requestURL += "&" + url.QueryEscape(q[0])
@@ -235,6 +240,16 @@ func (o *OctopusApiClient) getCollectionRequest(resourceType string, queryParams
 		if len(q) == 2 {
 			requestURL += "&" + url.QueryEscape(q[0]) + "=" + url.QueryEscape(q[1])
 		}
+	}
+
+	if !foundTake {
+		if len(queryParams) == 0 {
+			requestURL += "&"
+		} else {
+			requestURL += "?"
+		}
+
+		requestURL += "take=10000"
 	}
 
 	req, err := http.NewRequest(http.MethodGet, requestURL, nil)

--- a/cmd/internal/converters/project_group_converter.go
+++ b/cmd/internal/converters/project_group_converter.go
@@ -49,7 +49,10 @@ func (c ProjectGroupConverter) allToHcl(stateless bool, dependencies *data.Resou
 		Client: c.Client,
 	}
 
-	channel := batchClient.GetAllResourcesBatch(c.GetResourceType())
+	done := make(chan struct{})
+	defer close(done)
+
+	channel := batchClient.GetAllResourcesBatch(done, c.GetResourceType())
 
 	for resourceWrapper := range channel {
 		if resourceWrapper.Err != nil {

--- a/cmd/internal/converters/project_group_converter.go
+++ b/cmd/internal/converters/project_group_converter.go
@@ -45,7 +45,7 @@ func (c ProjectGroupConverter) allToHcl(stateless bool, dependencies *data.Resou
 		return nil
 	}
 
-	batchClient := client.GenericOctopusApiClient[octopus.ProjectGroup]{
+	batchClient := client.BatchingOctopusApiClient[octopus.ProjectGroup]{
 		Client: c.Client,
 	}
 

--- a/test/terraform/70-lotsofproject/space_creation/config.tf
+++ b/test/terraform/70-lotsofproject/space_creation/config.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_providers {
+    octopusdeploy = { source = "OctopusDeployLabs/octopusdeploy", version = "0.13.2" }
+  }
+}

--- a/test/terraform/70-lotsofproject/space_creation/provider.tf
+++ b/test/terraform/70-lotsofproject/space_creation/provider.tf
@@ -1,0 +1,4 @@
+provider "octopusdeploy" {
+  address = "${var.octopus_server}"
+  api_key = "${var.octopus_apikey}"
+}

--- a/test/terraform/70-lotsofproject/space_creation/provider_vars.tf
+++ b/test/terraform/70-lotsofproject/space_creation/provider_vars.tf
@@ -1,0 +1,18 @@
+variable "octopus_server" {
+  type        = string
+  nullable    = false
+  sensitive   = false
+  description = "The URL of the Octopus server e.g. https://myinstance.octopus.app."
+}
+variable "octopus_apikey" {
+  type        = string
+  nullable    = false
+  sensitive   = true
+  description = "The API key used to access the Octopus server. See https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key for details on creating an API key."
+}
+variable "octopus_space_id" {
+  type        = string
+  nullable    = false
+  sensitive   = false
+  description = "The space ID to populate"
+}

--- a/test/terraform/70-lotsofproject/space_creation/space.tf
+++ b/test/terraform/70-lotsofproject/space_creation/space.tf
@@ -1,0 +1,19 @@
+resource "octopusdeploy_space" "octopus_space_test" {
+  name                  = "${var.octopus_space_name}"
+  is_default            = false
+  is_task_queue_stopped = false
+  description           = "My test space"
+  space_managers_teams  = ["teams-administrators"]
+}
+
+output "octopus_space_id" {
+  value = octopusdeploy_space.octopus_space_test.id
+}
+
+variable "octopus_space_name" {
+  type        = string
+  nullable    = false
+  sensitive   = false
+  description = "The name of the new space"
+  default     = "Test"
+}

--- a/test/terraform/70-lotsofproject/space_population/config.tf
+++ b/test/terraform/70-lotsofproject/space_population/config.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_providers {
+    octopusdeploy = { source = "OctopusDeployLabs/octopusdeploy", version = "0.13.2" }
+  }
+}

--- a/test/terraform/70-lotsofproject/space_population/docker_feed.tf
+++ b/test/terraform/70-lotsofproject/space_population/docker_feed.tf
@@ -1,0 +1,8 @@
+resource "octopusdeploy_docker_container_registry" "feed_docker" {
+  name                                 = "Docker"
+  password                             = "password"
+  username                             = "username"
+  api_version                          = "v1"
+  feed_uri                             = "https://index.docker.io"
+  package_acquisition_location_options = ["ExecutionTarget", "NotAcquired"]
+}

--- a/test/terraform/70-lotsofproject/space_population/project.tf
+++ b/test/terraform/70-lotsofproject/space_population/project.tf
@@ -1,0 +1,82 @@
+data "octopusdeploy_lifecycles" "lifecycle_default_lifecycle" {
+  ids          = null
+  partial_name = "Default Lifecycle"
+  skip         = 0
+  take         = 1
+}
+
+resource "octopusdeploy_project" "deploy_frontend_project" {
+  count = 100
+  auto_create_release                  = false
+  default_guided_failure_mode          = "EnvironmentDefault"
+  default_to_skip_if_already_installed = false
+  description                          = "Test project ${count.index + 1}"
+  discrete_channel_release             = false
+  is_disabled                          = false
+  is_discrete_channel_release          = false
+  is_version_controlled                = false
+  lifecycle_id                         = data.octopusdeploy_lifecycles.lifecycle_default_lifecycle.lifecycles[0].id
+  name                                 = "Test ${count.index + 1}"
+  project_group_id                     = octopusdeploy_project_group.project_group_test.id
+  tenanted_deployment_participation    = "Untenanted"
+  space_id                             = var.octopus_space_id
+  included_library_variable_sets       = []
+  versioning_strategy {
+    template = "#{Octopus.Version.LastMajor}.#{Octopus.Version.LastMinor}.#{Octopus.Version.LastPatch}.#{Octopus.Version.NextRevision}"
+  }
+
+  connectivity_policy {
+    allow_deployments_to_no_targets = false
+    exclude_unhealthy_targets       = false
+    skip_machine_behavior           = "SkipUnavailableMachines"
+  }
+}
+
+resource "octopusdeploy_deployment_process" "test" {
+  project_id = octopusdeploy_project.deploy_frontend_project[count.index].id
+  count = 100
+
+  step {
+    condition           = "Success"
+    name                = "Get MySQL Host"
+    package_requirement = "LetOctopusDecide"
+    start_trigger       = "StartAfterPrevious"
+
+    action {
+      action_type                        = "Octopus.KubernetesRunScript"
+      name                               = "Get MySQL Host"
+      condition                          = "Success"
+      run_on_server                      = true
+      is_disabled                        = false
+      can_be_used_for_project_versioning = true
+      is_required                        = false
+      worker_pool_id                     = ""
+      properties                         = {
+        "Octopus.Action.Script.ScriptBody" = "echo \"hi\""
+        "Octopus.Action.KubernetesContainers.Namespace" = ""
+        "OctopusUseBundledTooling" = "False"
+        "Octopus.Action.Script.ScriptSource" = "Inline"
+        "Octopus.Action.Script.Syntax" = "Bash"
+      }
+
+      environments          = []
+      excluded_environments = []
+      channels              = []
+      tenant_tags           = []
+
+      package {
+        name                      = "package1"
+        package_id                = "package1"
+        acquisition_location      = "Server"
+        extract_during_deployment = false
+        feed_id                   = octopusdeploy_docker_container_registry.feed_docker.id
+        properties                = { Extract = "True", Purpose = "", SelectionMode = "immediate" }
+      }
+
+      features = []
+    }
+
+    properties   = {}
+    target_roles = ["eks"]
+  }
+}

--- a/test/terraform/70-lotsofproject/space_population/project_group_test.tf
+++ b/test/terraform/70-lotsofproject/space_population/project_group_test.tf
@@ -1,0 +1,4 @@
+resource "octopusdeploy_project_group" "project_group_test" {
+  name        = "Test"
+  description = "Test Description"
+}

--- a/test/terraform/70-lotsofproject/space_population/provider.tf
+++ b/test/terraform/70-lotsofproject/space_population/provider.tf
@@ -1,0 +1,5 @@
+provider "octopusdeploy" {
+  address  = "${var.octopus_server}"
+  api_key  = "${var.octopus_apikey}"
+  space_id = "${var.octopus_space_id}"
+}

--- a/test/terraform/70-lotsofproject/space_population/provider_vars.tf
+++ b/test/terraform/70-lotsofproject/space_population/provider_vars.tf
@@ -1,0 +1,18 @@
+variable "octopus_server" {
+  type        = string
+  nullable    = false
+  sensitive   = false
+  description = "The URL of the Octopus server e.g. https://myinstance.octopus.app."
+}
+variable "octopus_apikey" {
+  type        = string
+  nullable    = false
+  sensitive   = true
+  description = "The API key used to access the Octopus server. See https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key for details on creating an API key."
+}
+variable "octopus_space_id" {
+  type        = string
+  nullable    = false
+  sensitive   = false
+  description = "The space ID to populate"
+}

--- a/test/terraform/70-lotsofproject/space_population/space.tf
+++ b/test/terraform/70-lotsofproject/space_population/space.tf
@@ -1,0 +1,3 @@
+output "octopus_space_id" {
+  value = var.octopus_space_id
+}


### PR DESCRIPTION
This PR adds a wrapper over the octopus client that supports batch API calls when loading resource collections and lazy iteration over the collection.