### PR TITLE
Add gitDependencies to the exported deployment process fields

### DIFF
--- a/cmd/internal/converters/deployment_process_converter.go
+++ b/cmd/internal/converters/deployment_process_converter.go
@@ -269,6 +269,7 @@ func (c DeploymentProcessConverter) toHcl(resource octopus.DeploymentProcess, pr
 					RunOnServer:                   c.OctopusActionProcessor.GetRunOnServer(a.Properties),
 					Properties:                    nil,
 					Features:                      c.OctopusActionProcessor.GetFeatures(a.Properties),
+					GitDependencies:               c.OctopusActionProcessor.ConvertGitDependencies(a.GitDependencies, dependencies),
 				}
 
 				for _, p := range a.Packages {

--- a/cmd/internal/converters/octopus_action_processor.go
+++ b/cmd/internal/converters/octopus_action_processor.go
@@ -160,6 +160,19 @@ func (c OctopusActionProcessor) ConvertContainer(container octopus.Container, de
 	return nil
 }
 
+func (c OctopusActionProcessor) ConvertGitDependencies(gitDependencies []octopus.GitDependency, dependencies *data.ResourceDetailsCollection) []terraform.TerraformGitDependency {
+	result := make([]terraform.TerraformGitDependency, len(gitDependencies))
+	for i, gitDependency := range gitDependencies {
+		result[i] = terraform.TerraformGitDependency{
+			RepositoryUri:     gitDependency.RepositoryUri,
+			DefaultBranch:     gitDependency.DefaultBranch,
+			GitCredentialType: gitDependency.GitCredentialType,
+			GitCredentialID:   dependencies.GetResourcePointer("Git-Credentials", gitDependency.GitCredentialId),
+		}
+	}
+	return result
+}
+
 func (c OctopusActionProcessor) ReplaceIds(properties map[string]string, dependencies *data.ResourceDetailsCollection) map[string]string {
 	properties = c.replaceAccountIds(properties, dependencies)
 	properties = c.replaceFeedIds(properties, dependencies)

--- a/cmd/internal/model/octopus/octopus_deployment_process.go
+++ b/cmd/internal/model/octopus/octopus_deployment_process.go
@@ -35,6 +35,17 @@ type Action struct {
 	Condition                     *string
 	Properties                    map[string]any
 	Inputs                        map[string]any
+	GitDependencies               []GitDependency
+}
+
+type GitDependency struct {
+	Name                         *string
+	RepositoryUri                *string
+	DefaultBranch                *string
+	GitCredentialType            *string
+	FilePathFilters              []string
+	GitCredentialId              *string
+	StepPackageInputsReferenceId *string
 }
 
 type Container struct {

--- a/cmd/internal/model/terraform/terraform_deployment_process.go
+++ b/cmd/internal/model/terraform/terraform_deployment_process.go
@@ -22,25 +22,33 @@ type TerraformStep struct {
 }
 
 type TerraformAction struct {
-	ActionType                    *string             `hcl:"action_type"`
-	Name                          *string             `hcl:"name"`
-	Notes                         *string             `hcl:"notes"`
-	Condition                     *string             `hcl:"condition"`
-	RunOnServer                   bool                `hcl:"run_on_server"`
-	IsDisabled                    bool                `hcl:"is_disabled"`
-	CanBeUsedForProjectVersioning bool                `hcl:"can_be_used_for_project_versioning"`
-	IsRequired                    bool                `hcl:"is_required"`
-	WorkerPoolId                  *string             `hcl:"worker_pool_id"`
-	WorkerPoolVariable            *string             `hcl:"worker_pool_variable"`
-	Properties                    map[string]string   `hcl:"properties"`
-	Container                     *TerraformContainer `hcl:"container,block"`
-	Environments                  []string            `hcl:"environments"`
-	ExcludedEnvironments          []string            `hcl:"excluded_environments"`
-	Channels                      []string            `hcl:"channels"`
-	TenantTags                    []string            `hcl:"tenant_tags"`
-	Package                       []TerraformPackage  `hcl:"package,block"`
-	PrimaryPackage                *TerraformPackage   `hcl:"primary_package,block"`
-	Features                      []string            `hcl:"features"`
+	ActionType                    *string                  `hcl:"action_type"`
+	Name                          *string                  `hcl:"name"`
+	Notes                         *string                  `hcl:"notes"`
+	Condition                     *string                  `hcl:"condition"`
+	RunOnServer                   bool                     `hcl:"run_on_server"`
+	IsDisabled                    bool                     `hcl:"is_disabled"`
+	CanBeUsedForProjectVersioning bool                     `hcl:"can_be_used_for_project_versioning"`
+	IsRequired                    bool                     `hcl:"is_required"`
+	WorkerPoolId                  *string                  `hcl:"worker_pool_id"`
+	WorkerPoolVariable            *string                  `hcl:"worker_pool_variable"`
+	Properties                    map[string]string        `hcl:"properties"`
+	Container                     *TerraformContainer      `hcl:"container,block"`
+	Environments                  []string                 `hcl:"environments"`
+	ExcludedEnvironments          []string                 `hcl:"excluded_environments"`
+	Channels                      []string                 `hcl:"channels"`
+	TenantTags                    []string                 `hcl:"tenant_tags"`
+	Package                       []TerraformPackage       `hcl:"package,block"`
+	PrimaryPackage                *TerraformPackage        `hcl:"primary_package,block"`
+	Features                      []string                 `hcl:"features"`
+	GitDependencies               []TerraformGitDependency `hcl:"git_dependency,block"`
+}
+
+type TerraformGitDependency struct {
+	RepositoryUri     *string `hcl:"repository_uri"`
+	DefaultBranch     *string `hcl:"default_branch"`
+	GitCredentialType *string `hcl:"git_credential_type"`
+	GitCredentialID   *string `hcl:"git_credential_id"`
 }
 
 type TerraformContainer struct {

--- a/test/terraform/74-gitdependencies/space_creation/config.tf
+++ b/test/terraform/74-gitdependencies/space_creation/config.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_providers {
+    octopusdeploy = { source = "OctopusDeployLabs/octopusdeploy", version = "0.13.2" }
+  }
+}

--- a/test/terraform/74-gitdependencies/space_creation/provider.tf
+++ b/test/terraform/74-gitdependencies/space_creation/provider.tf
@@ -1,0 +1,4 @@
+provider "octopusdeploy" {
+  address = "${var.octopus_server}"
+  api_key = "${var.octopus_apikey}"
+}

--- a/test/terraform/74-gitdependencies/space_creation/provider_vars.tf
+++ b/test/terraform/74-gitdependencies/space_creation/provider_vars.tf
@@ -1,0 +1,18 @@
+variable "octopus_server" {
+  type        = string
+  nullable    = false
+  sensitive   = false
+  description = "The URL of the Octopus server e.g. https://myinstance.octopus.app."
+}
+variable "octopus_apikey" {
+  type        = string
+  nullable    = false
+  sensitive   = true
+  description = "The API key used to access the Octopus server. See https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key for details on creating an API key."
+}
+variable "octopus_space_id" {
+  type        = string
+  nullable    = false
+  sensitive   = false
+  description = "The space ID to populate"
+}

--- a/test/terraform/74-gitdependencies/space_creation/space.tf
+++ b/test/terraform/74-gitdependencies/space_creation/space.tf
@@ -1,0 +1,19 @@
+resource "octopusdeploy_space" "octopus_space_test" {
+  name                  = "${var.octopus_space_name}"
+  is_default            = false
+  is_task_queue_stopped = false
+  description           = "My test space"
+  space_managers_teams  = ["teams-administrators"]
+}
+
+output "octopus_space_id" {
+  value = octopusdeploy_space.octopus_space_test.id
+}
+
+variable "octopus_space_name" {
+  type        = string
+  nullable    = false
+  sensitive   = false
+  description = "The name of the new space"
+  default     = "Test"
+}

--- a/test/terraform/74-gitdependencies/space_population/config.tf
+++ b/test/terraform/74-gitdependencies/space_population/config.tf
@@ -1,0 +1,5 @@
+terraform {
+  required_providers {
+    octopusdeploy = { source = "OctopusDeployLabs/octopusdeploy", version = "0.18.3" }
+  }
+}

--- a/test/terraform/74-gitdependencies/space_population/gitcredential.tf
+++ b/test/terraform/74-gitdependencies/space_population/gitcredential.tf
@@ -1,0 +1,14 @@
+resource "octopusdeploy_git_credential" "gitcredential_test" {
+  description = "test git credential"
+  name        = "test"
+  type        = "UsernamePassword"
+  username    = "admin"
+  password    = "${var.gitcredential_test}"
+}
+variable "gitcredential_test" {
+  type        = string
+  nullable    = false
+  sensitive   = true
+  description = "The secret variable value associated with the git credential test"
+  default     = "Password01!"
+}

--- a/test/terraform/74-gitdependencies/space_population/project.tf
+++ b/test/terraform/74-gitdependencies/space_population/project.tf
@@ -1,0 +1,82 @@
+data "octopusdeploy_lifecycles" "lifecycle_default_lifecycle" {
+  ids          = null
+  partial_name = "Default Lifecycle"
+  skip         = 0
+  take         = 1
+}
+
+resource "octopusdeploy_variable" "string_variable" {
+  owner_id  = octopusdeploy_project.deploy_frontend_project.id
+  type      = "String"
+  name      = "Test"
+  value     = "PlainText"
+}
+
+resource "octopusdeploy_project" "deploy_frontend_project" {
+  auto_create_release                  = false
+  default_guided_failure_mode          = "EnvironmentDefault"
+  default_to_skip_if_already_installed = false
+  description                          = "Test project"
+  discrete_channel_release             = false
+  is_disabled                          = false
+  is_discrete_channel_release          = false
+  is_version_controlled                = false
+  lifecycle_id                         = data.octopusdeploy_lifecycles.lifecycle_default_lifecycle.lifecycles[0].id
+  name                                 = "Test"
+  project_group_id                     = octopusdeploy_project_group.project_group_test.id
+  tenanted_deployment_participation    = "Untenanted"
+  space_id                             = var.octopus_space_id
+  included_library_variable_sets       = []
+  versioning_strategy {
+    template = "#{Octopus.Version.LastMajor}.#{Octopus.Version.LastMinor}.#{Octopus.Version.LastPatch}.#{Octopus.Version.NextRevision}"
+  }
+
+  connectivity_policy {
+    allow_deployments_to_no_targets = false
+    exclude_unhealthy_targets       = false
+    skip_machine_behavior           = "SkipUnavailableMachines"
+  }
+}
+
+resource "octopusdeploy_deployment_process" "test" {
+  project_id = octopusdeploy_project.deploy_frontend_project.id
+
+  step {
+    condition           = "Success"
+    name                = "Deploy a Helm Chart"
+    package_requirement = "LetOctopusDecide"
+    start_trigger       = "StartAfterPrevious"
+
+    action {
+      action_type                        = "Octopus.HelmChartUpgrade"
+      name                               = "Deploy a Helm Chart"
+      condition                          = "Success"
+      run_on_server                      = true
+      is_disabled                        = false
+      can_be_used_for_project_versioning = false
+      is_required                        = false
+      worker_pool_variable               = ""
+      properties                         = {
+        "Octopus.Action.Helm.ResetValues" = "True"
+        "Octopus.Action.Helm.ClientVersion" = "V3"
+        "Octopus.Action.Script.ScriptSource" = "GitRepository"
+        "Octopus.Action.GitRepository.Source" = "External"
+        "Octopus.Action.Helm.ReleaseName" = "aaa"
+      }
+      git_dependency {
+        repository_uri = 	"https://github.com/OctopusDeploy/OctopusClients.git"
+        git_credential_type = "Library"
+        git_credential_id = octopusdeploy_git_credential.gitcredential_test.id
+        default_branch = "main"
+      }
+      environments                       = []
+      excluded_environments              = []
+      channels                           = []
+      tenant_tags                        = []
+      features                           = []
+    }
+
+    properties   = {}
+    target_roles = []
+  }
+}

--- a/test/terraform/74-gitdependencies/space_population/project_group_test.tf
+++ b/test/terraform/74-gitdependencies/space_population/project_group_test.tf
@@ -1,0 +1,4 @@
+resource "octopusdeploy_project_group" "project_group_test" {
+  name        = "Test"
+  description = "Test Description"
+}

--- a/test/terraform/74-gitdependencies/space_population/provider.tf
+++ b/test/terraform/74-gitdependencies/space_population/provider.tf
@@ -1,0 +1,5 @@
+provider "octopusdeploy" {
+  address  = "${var.octopus_server}"
+  api_key  = "${var.octopus_apikey}"
+  space_id = "${var.octopus_space_id}"
+}

--- a/test/terraform/74-gitdependencies/space_population/provider_vars.tf
+++ b/test/terraform/74-gitdependencies/space_population/provider_vars.tf
@@ -1,0 +1,18 @@
+variable "octopus_server" {
+  type        = string
+  nullable    = false
+  sensitive   = false
+  description = "The URL of the Octopus server e.g. https://myinstance.octopus.app."
+}
+variable "octopus_apikey" {
+  type        = string
+  nullable    = false
+  sensitive   = true
+  description = "The API key used to access the Octopus server. See https://octopus.com/docs/octopus-rest-api/how-to-create-an-api-key for details on creating an API key."
+}
+variable "octopus_space_id" {
+  type        = string
+  nullable    = false
+  sensitive   = false
+  description = "The space ID to populate"
+}

--- a/test/terraform/74-gitdependencies/space_population/space.tf
+++ b/test/terraform/74-gitdependencies/space_population/space.tf
@@ -1,0 +1,3 @@
+output "octopus_space_id" {
+  value = var.octopus_space_id
+}


### PR DESCRIPTION
The [git_dependency](https://github.com/OctopusDeployLabs/terraform-provider-octopusdeploy/blob/main/octopusdeploy/schema_deployment_action.go#L225) block is required for deployment actions that reference git. This PR adds support to allow this field to be exported.

Internal Slack [thread](https://octopusdeploy.slack.com/archives/C056NSRCRAL/p1713830272891899) for more context.

[sc-76804]